### PR TITLE
fix: use window.location.origin instead of NEXT_PUBLIC_APP_URL for OA…

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -8,6 +8,3 @@ ANTHROPIC_API_KEY=xxxx
 
 # Rakuten Travel API
 RAKUTEN_APPLICATION_ID=xxxx
-
-# App
-NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -9,7 +9,7 @@ export default function LoginPage() {
     await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/auth/callback`,
+        redirectTo: `${window.location.origin}/auth/callback`,
       },
     });
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000',
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
     trace: 'on-first-retry',
   },
   projects: [


### PR DESCRIPTION
…uth redirect

Replace hardcoded NEXT_PUBLIC_APP_URL with window.location.origin so that OAuth redirects work correctly on any Vercel deploy URL (production and preview). This eliminates the PKCE code_verifier mismatch caused by undefined env var.

- Remove NEXT_PUBLIC_APP_URL from .env.local.example
- Update playwright.config.ts to use BASE_URL instead

https://claude.ai/code/session_01B8CHCZjM984ZKUALNcsVx9