### PR TITLE
debug: applicationId のログ出力を追加して認証エラーの原因を調査

### DIFF
--- a/src/lib/rakuten/hotels.ts
+++ b/src/lib/rakuten/hotels.ts
@@ -63,7 +63,7 @@ export class RakutenApiError extends Error {
 export async function searchHotels(
   params: HotelSearchParams,
 ): Promise<HotelSearchResult> {
-  const applicationId = process.env.RAKUTEN_APPLICATION_ID;
+  const applicationId = process.env.RAKUTEN_APPLICATION_ID?.trim();
   if (!applicationId) {
     throw new RakutenApiError(
       'RAKUTEN_APPLICATION_ID が設定されていません',
@@ -90,6 +90,7 @@ export async function searchHotels(
   }
 
   const url = `${SIMPLE_HOTEL_SEARCH}?${searchParams.toString()}`;
+  console.log('[RakutenAPI] applicationId length:', applicationId.length, 'prefix:', applicationId.slice(0, 4));
 
   let response: Response;
   try {


### PR DESCRIPTION
Vercel上で設定済みの RAKUTEN_APPLICATION_ID が楽天APIに
拒否される問題の調査用。ID長とプレフィックスをログに出力する。
また .trim() で前後の空白を除去するよう修正。

https://claude.ai/code/session_01Jc6XHfbdEemuH6UPUDmocy