### PR TITLE
feat: AI旅行予算見積もり機能を追加

### DIFF
--- a/app/(protected)/saved/[id]/page.tsx
+++ b/app/(protected)/saved/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, use } from 'react';
 import { useRouter } from 'next/navigation';
 import type { SavedProposal } from '@/src/types';
+import BudgetEstimate from '@/src/components/budget/BudgetEstimate';
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -153,6 +154,9 @@ export default function SavedDetailPage({ params }: Props) {
 
         <p className="text-xs italic text-[var(--color-neutral-700)]">{dest.tips}</p>
       </section>
+
+      {/* Budget estimate section */}
+      <BudgetEstimate destination={dest} />
 
       {/* Memo section */}
       <section aria-label="メモ" className="border border-[var(--border)] rounded-xl p-4">

--- a/app/api/budget-estimate/route.ts
+++ b/app/api/budget-estimate/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { estimateBudget, EstimateError } from '@/src/lib/claude/estimate';
+import { createClient } from '@/src/lib/supabase/server';
+
+// ---------------------------------------------------------------------------
+// Request schema
+// ---------------------------------------------------------------------------
+
+const RequestSchema = z.object({
+  destination: z.string().min(1),
+  familyProfile: z.object({
+    adultCount: z.number().int().min(1).max(10),
+    childrenAges: z.array(z.number().int().min(0).max(17)).default([]),
+  }),
+  season: z.enum(['spring', 'summer', 'autumn', 'winter']),
+  style: z.enum(['nature', 'culture', 'resort', 'onsen', 'city']),
+  area: z.enum(['domestic', 'overseas']),
+  nights: z.number().int().min(1).max(30),
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/budget-estimate
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const supabase: any = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'リクエストボディが不正です' }, { status: 400 });
+  }
+
+  const parsed = RequestSchema.safeParse(body);
+  if (!parsed.success) {
+    const fields = parsed.error.issues.map((issue) => issue.path.join('.'));
+    return NextResponse.json(
+      { error: '条件が不足しています', fields },
+      { status: 400 },
+    );
+  }
+
+  const { destination, familyProfile, season, style, area, nights } = parsed.data;
+
+  try {
+    const result = await estimateBudget(destination, familyProfile, season, style, area, nights);
+    return NextResponse.json(result, { status: 200 });
+  } catch (err: unknown) {
+    if (err instanceof EstimateError) {
+      if (err.code === 'TIMEOUT') {
+        return NextResponse.json(
+          { error: '見積もりの生成に時間がかかっています。再度お試しください。' },
+          { status: 504 },
+        );
+      }
+      if (err.code === 'VALIDATION_ERROR') {
+        return NextResponse.json({ error: err.message }, { status: 400 });
+      }
+    }
+    console.error('[POST /api/budget-estimate] unexpected error:', err);
+    return NextResponse.json(
+      { error: '見積もりの生成に失敗しました' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/budget/BudgetEstimate.tsx
+++ b/src/components/budget/BudgetEstimate.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useState } from 'react';
+import type {
+  Destination,
+  BudgetEstimateResponse,
+  BudgetEstimateRequest,
+} from '@/src/types';
+
+// ---------------------------------------------------------------------------
+// Category colors
+// ---------------------------------------------------------------------------
+
+const CATEGORY_COLORS: Record<string, string> = {
+  '交通費': 'bg-blue-500',
+  '宿泊費': 'bg-amber-500',
+  '食費': 'bg-green-500',
+  'アクティビティ・観光': 'bg-purple-500',
+  'その他（お土産・雑費）': 'bg-gray-400',
+};
+
+function getCategoryColor(category: string): string {
+  return CATEGORY_COLORS[category] ?? 'bg-gray-400';
+}
+
+// ---------------------------------------------------------------------------
+// Format helpers
+// ---------------------------------------------------------------------------
+
+function formatYen(amount: number): string {
+  if (amount >= 10000) {
+    const man = Math.round(amount / 1000) / 10;
+    return `${man}万円`;
+  }
+  return `${amount.toLocaleString('ja-JP')}円`;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface Props {
+  destination: Destination;
+}
+
+export default function BudgetEstimate({ destination }: Props) {
+  const [nights, setNights] = useState(2);
+  const [adultCount, setAdultCount] = useState(2);
+  const [childrenAgesText, setChildrenAgesText] = useState('');
+  const [season, setSeason] = useState<BudgetEstimateRequest['season']>('spring');
+  const [style, setStyle] = useState<BudgetEstimateRequest['style']>('nature');
+  const [area, setArea] = useState<BudgetEstimateRequest['area']>('domestic');
+  const [isLoading, setIsLoading] = useState(false);
+  const [result, setResult] = useState<BudgetEstimateResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  async function handleEstimate() {
+    setIsLoading(true);
+    setError(null);
+    setResult(null);
+
+    const childrenAges = childrenAgesText
+      .split(/[,、\s]+/)
+      .map((str: string) => parseInt(str, 10))
+      .filter((num: number) => !isNaN(num) && num >= 0 && num <= 17);
+
+    try {
+      const res = await fetch('/api/budget-estimate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          destination: destination.name,
+          familyProfile: { adultCount, childrenAges },
+          season,
+          style,
+          area,
+          nights,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || '見積もりに失敗しました');
+      }
+
+      const data: BudgetEstimateResponse = await res.json();
+      setResult(data);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : '見積もりに失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <section aria-label="予算見積もり" className="border border-[var(--border)] rounded-xl overflow-hidden">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-[var(--color-neutral-50)] transition-colors"
+      >
+        <h2 className="text-sm font-semibold text-[var(--foreground)] flex items-center gap-2">
+          <span aria-hidden="true" className="text-base">&#128176;</span>
+          予算を詳しく見積もる
+        </h2>
+        <span className="text-xs text-[var(--color-neutral-500)]">
+          {isOpen ? '閉じる' : '開く'}
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="px-4 pb-4 space-y-4 border-t border-[var(--border)]">
+          {/* Input form */}
+          <div className="grid grid-cols-2 gap-3 pt-4">
+            <div>
+              <label htmlFor="est-nights" className="block text-xs font-medium text-[var(--color-neutral-700)] mb-1">
+                宿泊数
+              </label>
+              <input
+                id="est-nights"
+                type="number"
+                min={1}
+                max={30}
+                value={nights}
+                onChange={(e) => setNights(parseInt(e.target.value, 10) || 1)}
+                className="w-full border border-[var(--border)] rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)]"
+              />
+            </div>
+            <div>
+              <label htmlFor="est-adults" className="block text-xs font-medium text-[var(--color-neutral-700)] mb-1">
+                大人人数
+              </label>
+              <input
+                id="est-adults"
+                type="number"
+                min={1}
+                max={10}
+                value={adultCount}
+                onChange={(e) => setAdultCount(parseInt(e.target.value, 10) || 1)}
+                className="w-full border border-[var(--border)] rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)]"
+              />
+            </div>
+            <div>
+              <label htmlFor="est-children" className="block text-xs font-medium text-[var(--color-neutral-700)] mb-1">
+                子供の年齢（カンマ区切り）
+              </label>
+              <input
+                id="est-children"
+                type="text"
+                placeholder="例: 5, 10"
+                value={childrenAgesText}
+                onChange={(e) => setChildrenAgesText(e.target.value)}
+                className="w-full border border-[var(--border)] rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)]"
+              />
+            </div>
+            <div>
+              <label htmlFor="est-season" className="block text-xs font-medium text-[var(--color-neutral-700)] mb-1">
+                時期
+              </label>
+              <select
+                id="est-season"
+                value={season}
+                onChange={(e) => setSeason(e.target.value as BudgetEstimateRequest['season'])}
+                className="w-full border border-[var(--border)] rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)]"
+              >
+                <option value="spring">春</option>
+                <option value="summer">夏</option>
+                <option value="autumn">秋</option>
+                <option value="winter">冬</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="est-style" className="block text-xs font-medium text-[var(--color-neutral-700)] mb-1">
+                スタイル
+              </label>
+              <select
+                id="est-style"
+                value={style}
+                onChange={(e) => setStyle(e.target.value as BudgetEstimateRequest['style'])}
+                className="w-full border border-[var(--border)] rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)]"
+              >
+                <option value="nature">自然体験</option>
+                <option value="culture">文化・歴史</option>
+                <option value="resort">リゾート</option>
+                <option value="onsen">温泉・のんびり</option>
+                <option value="city">都市観光</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="est-area" className="block text-xs font-medium text-[var(--color-neutral-700)] mb-1">
+                エリア
+              </label>
+              <select
+                id="est-area"
+                value={area}
+                onChange={(e) => setArea(e.target.value as BudgetEstimateRequest['area'])}
+                className="w-full border border-[var(--border)] rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-500)]"
+              >
+                <option value="domestic">国内</option>
+                <option value="overseas">海外</option>
+              </select>
+            </div>
+          </div>
+
+          <button
+            onClick={handleEstimate}
+            disabled={isLoading}
+            className="w-full py-2.5 bg-[var(--color-primary-600)] text-white text-sm font-medium rounded-lg hover:bg-[var(--color-primary-700)] disabled:opacity-50 transition-colors"
+          >
+            {isLoading ? 'AIが見積もり中...' : '見積もりを取得'}
+          </button>
+
+          {/* Error */}
+          {error && (
+            <div role="alert" className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+
+          {/* Results */}
+          {result && (
+            <div className="space-y-4 pt-2">
+              {/* Total */}
+              <div className="text-center p-4 bg-[var(--color-primary-50)] rounded-xl border border-[var(--color-primary-100)]">
+                <p className="text-xs text-[var(--color-neutral-700)] mb-1">家族全員の合計見積もり</p>
+                <p className="text-xl font-bold text-[var(--color-primary-700)]">
+                  {formatYen(result.totalMin)} 〜 {formatYen(result.totalMax)}
+                </p>
+              </div>
+
+              {/* Category breakdown */}
+              <div className="space-y-3">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--color-neutral-700)]">
+                  カテゴリ別内訳
+                </h3>
+                {result.categories.map((cat) => {
+                  const maxBudget = Math.max(...result.categories.map((c) => c.estimatedMax));
+                  const barWidth = maxBudget > 0 ? (cat.estimatedMax / maxBudget) * 100 : 0;
+
+                  return (
+                    <div key={cat.category} className="space-y-1">
+                      <div className="flex justify-between items-baseline">
+                        <span className="text-sm font-medium text-[var(--foreground)]">
+                          {cat.category}
+                        </span>
+                        <span className="text-sm text-[var(--color-neutral-700)]">
+                          {formatYen(cat.estimatedMin)} 〜 {formatYen(cat.estimatedMax)}
+                        </span>
+                      </div>
+                      <div className="h-3 bg-[var(--color-neutral-100)] rounded-full overflow-hidden">
+                        <div
+                          className={`h-full rounded-full ${getCategoryColor(cat.category)} transition-all duration-500`}
+                          style={{ width: `${barWidth}%` }}
+                        />
+                      </div>
+                      <p className="text-xs text-[var(--color-neutral-500)]">{cat.note}</p>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Advice */}
+              <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                <p className="text-xs font-semibold text-amber-700 mb-1">節約のコツ</p>
+                <p className="text-sm text-amber-800">{result.advice}</p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/lib/claude/estimate.ts
+++ b/src/lib/claude/estimate.ts
@@ -1,0 +1,197 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type {
+  FamilyProfile,
+  TripCondition,
+  BudgetEstimateResponse,
+} from '@/src/types';
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+export class EstimateError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'VALIDATION_ERROR' | 'TIMEOUT' | 'INVALID_RESPONSE' | 'API_ERROR',
+  ) {
+    super(message);
+    this.name = 'EstimateError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Labels
+// ---------------------------------------------------------------------------
+
+const SEASON_LABELS: Record<TripCondition['season'], string> = {
+  spring: '春（3〜5月）',
+  summer: '夏（6〜8月）',
+  autumn: '秋（9〜11月）',
+  winter: '冬（12〜2月）',
+};
+
+const STYLE_LABELS: Record<TripCondition['style'], string> = {
+  nature: '自然体験',
+  culture: '文化・歴史',
+  resort: 'リゾート',
+  onsen: '温泉・のんびり',
+  city: '都市観光',
+};
+
+// ---------------------------------------------------------------------------
+// Prompt
+// ---------------------------------------------------------------------------
+
+function buildEstimatePrompt(
+  destination: string,
+  profile: FamilyProfile,
+  season: TripCondition['season'],
+  style: TripCondition['style'],
+  area: TripCondition['area'],
+  nights: number,
+): string {
+  const childrenDesc =
+    profile.childrenAges.length > 0
+      ? `子供 ${profile.childrenAges.length} 名（年齢: ${profile.childrenAges.join(', ')} 歳）`
+      : '子供なし';
+
+  return `あなたは旅行の費用見積もりの専門家です。
+以下の条件で旅行した場合の費用を、カテゴリ別に見積もってください。
+
+## 旅行先
+${destination}
+
+## 家族構成
+- 大人: ${profile.adultCount} 名
+- ${childrenDesc}
+
+## 旅行条件
+- 時期: ${SEASON_LABELS[season]}
+- スタイル: ${STYLE_LABELS[style]}
+- エリア: ${area === 'domestic' ? '国内' : '海外'}
+- 宿泊数: ${nights} 泊
+
+## 出力形式
+以下の JSON のみを返してください（コードブロック不要）:
+{
+  "totalMin": 最小合計額（数値・円）,
+  "totalMax": 最大合計額（数値・円）,
+  "categories": [
+    {
+      "category": "交通費",
+      "estimatedMin": 最小（数値・円）,
+      "estimatedMax": 最大（数値・円）,
+      "note": "補足（例: 新幹線利用の場合）"
+    },
+    {
+      "category": "宿泊費",
+      "estimatedMin": 最小,
+      "estimatedMax": 最大,
+      "note": "補足"
+    },
+    {
+      "category": "食費",
+      "estimatedMin": 最小,
+      "estimatedMax": 最大,
+      "note": "補足"
+    },
+    {
+      "category": "アクティビティ・観光",
+      "estimatedMin": 最小,
+      "estimatedMax": 最大,
+      "note": "補足"
+    },
+    {
+      "category": "その他（お土産・雑費）",
+      "estimatedMin": 最小,
+      "estimatedMax": 最大,
+      "note": "補足"
+    }
+  ],
+  "advice": "費用を抑えるためのアドバイス（2〜3文）"
+}
+
+## 注意
+- 費用は家族全員分の合計
+- 現実的で具体的な金額を示すこと
+- totalMin/totalMax は categories の合計と一致させること
+- JSON 以外のテキストを含めないこと`;
+}
+
+// ---------------------------------------------------------------------------
+// Main function
+// ---------------------------------------------------------------------------
+
+const TIMEOUT_MS = 28_000;
+
+export async function estimateBudget(
+  destination: string,
+  profile: FamilyProfile,
+  season: TripCondition['season'],
+  style: TripCondition['style'],
+  area: TripCondition['area'],
+  nights: number,
+): Promise<BudgetEstimateResponse> {
+  if (nights < 1 || nights > 30) {
+    throw new EstimateError('宿泊数は1〜30の範囲で指定してください', 'VALIDATION_ERROR');
+  }
+
+  const client = new Anthropic({
+    apiKey: process.env.ANTHROPIC_API_KEY,
+  });
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  let rawText: string;
+
+  try {
+    const message = await client.messages.create(
+      {
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 2048,
+        messages: [
+          {
+            role: 'user',
+            content: buildEstimatePrompt(destination, profile, season, style, area, nights),
+          },
+        ],
+      },
+      { signal: controller.signal },
+    );
+
+    rawText =
+      message.content[0]?.type === 'text' ? message.content[0].text : '';
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      (err.name === 'AbortError' || err.message.includes('aborted'))
+    ) {
+      throw new EstimateError('見積もりの生成がタイムアウトしました', 'TIMEOUT');
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new EstimateError(`Claude API エラー: ${msg}`, 'API_ERROR');
+  } finally {
+    clearTimeout(timer);
+  }
+
+  let parsed: BudgetEstimateResponse;
+  try {
+    const json = rawText.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
+    parsed = JSON.parse(json);
+  } catch {
+    throw new EstimateError(
+      `レスポンスが JSON として解析できませんでした: ${rawText.slice(0, 200)}`,
+      'INVALID_RESPONSE',
+    );
+  }
+
+  if (!Array.isArray(parsed.categories) || parsed.categories.length === 0) {
+    throw new EstimateError(
+      'レスポンスに categories が含まれていません',
+      'INVALID_RESPONSE',
+    );
+  }
+
+  return parsed;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -131,6 +131,36 @@ export interface ApiError {
 }
 
 // ============================================================
+// Budget Estimate Types — 旅行予算見積もり
+// ============================================================
+
+/** 予算カテゴリ別の見積もり */
+export interface BudgetCategory {
+  category: string;            // カテゴリ名（例: 交通費、宿泊費）
+  estimatedMin: number;        // 最小見積もり（円）
+  estimatedMax: number;        // 最大見積もり（円）
+  note: string;                // 補足説明
+}
+
+/** 予算見積もりレスポンス */
+export interface BudgetEstimateResponse {
+  totalMin: number;            // 合計最小（円）
+  totalMax: number;            // 合計最大（円）
+  categories: BudgetCategory[];
+  advice: string;              // 節約のコツ等
+}
+
+/** 予算見積もりリクエスト */
+export interface BudgetEstimateRequest {
+  destination: string;         // 旅行先名
+  familyProfile: FamilyProfile;
+  season: TripCondition['season'];
+  style: TripCondition['style'];
+  area: TripCondition['area'];
+  nights: number;              // 宿泊数
+}
+
+// ============================================================
 // Hearing Types — インタラクティブ・ヒアリング
 // ============================================================
 


### PR DESCRIPTION
## Summary
- 保存済み提案の詳細ページに「予算を詳しく見積もる」セクションを追加
- Claude Haiku AIが交通費・宿泊費・食費・アクティビティ・その他の5カテゴリで旅行費用を見積もり
- 家族構成・宿泊数・時期・スタイル・エリアを指定してカスタマイズ可能
- カテゴリ別の棒グラフ風UIと節約アドバイスを表示

## 変更内容
| ファイル | 内容 |
|---------|------|
| `src/types/index.ts` | `BudgetCategory`, `BudgetEstimateResponse`, `BudgetEstimateRequest` 型追加 |
| `src/lib/claude/estimate.ts` | Claude APIを使った予算見積もりロジック |
| `app/api/budget-estimate/route.ts` | `POST /api/budget-estimate` エンドポイント |
| `src/components/budget/BudgetEstimate.tsx` | 見積もりUI（入力フォーム＋結果表示） |
| `app/(protected)/saved/[id]/page.tsx` | BudgetEstimateコンポーネントの組み込み |

## Test plan
- [ ] 保存済み提案の詳細ページで「予算を詳しく見積もる」が表示される
- [ ] 開閉トグルが正しく動作する
- [ ] 各入力フィールド（宿泊数、大人人数、子供年齢、時期、スタイル、エリア）が正しく動作する
- [ ] 見積もり取得ボタンでAPIが呼ばれ、結果が表示される
- [ ] カテゴリ別内訳の棒グラフが正しく描画される
- [ ] エラー時にエラーメッセージが表示される
- [ ] 未認証ユーザーは401が返る

https://claude.ai/code/session_01REYPTyd1yrL1352UKvJ3EE